### PR TITLE
Null check for global $post

### DIFF
--- a/includes/page-assets-common.php
+++ b/includes/page-assets-common.php
@@ -13,6 +13,11 @@ if ( ! class_exists( 'UCF_Page_Assets_Common' ) ) {
 		public static function enqueue_assets() {
 			global $post;
 
+			// Global post isn't set. Bail!
+			if ( ! $post ) {
+				return;
+			}
+
 			$stylesheet_id = (int)get_post_meta( $post->ID, 'page_stylesheet', TRUE );
 			$javascript_id = (int)get_post_meta( $post->ID, 'page_javascript', TRUE );
 


### PR DESCRIPTION
Bug Fixes:
* Notice was being thrown when the `enqueue_assets` function ran on non-post templates as the global `$post` object is null.

Fixes #10 